### PR TITLE
Kxi 21090 propagate null support to remaining kdb types

### DIFF
--- a/src/ArrayWriter.cpp
+++ b/src/ArrayWriter.cpp
@@ -448,10 +448,10 @@ template<>
 void PopulateBuilder<arrow::Type::BOOL>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto bool_builder = static_cast<arrow::BooleanBuilder*>(builder);
-  if( type_overrides.null_mapping.have_uint8 ){
+  if( type_overrides.null_mapping.have_boolean ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.uint8_null ^ kG( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.boolean_null ^ kG( k_array )[i];
     }
     PARQUET_THROW_NOT_OK( bool_builder->AppendValues( ( uint8_t* )kG( k_array ), k_array->n, null_bitmap ) );
   }

--- a/src/ArrayWriter.cpp
+++ b/src/ArrayWriter.cpp
@@ -1,7 +1,9 @@
 #include <memory>
+#include <limits>
 #include <unordered_map>
 #include <iostream>
 #include <stdexcept>
+#include <cmath>
 
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
@@ -19,6 +21,18 @@ using namespace kx::arrowkdb;
 
 namespace
 {
+
+//! Compares floating point numbers, because of unreliable direct compare
+//! @param lhs - left-hand side value
+//! @param rhs - right-hand side value
+//! @return true if values are nearby
+template<typename T>
+bool is_equal( T lhs, T rhs )
+{
+    static const T epsilon = 2 * std::numeric_limits<T>::epsilon();
+
+    return ::fabs(lhs -= rhs) <= epsilon;
+}
 
 shared_ptr<arrow::ArrayBuilder> GetBuilder(shared_ptr<arrow::DataType> datatype);
 
@@ -434,29 +448,64 @@ template<>
 void PopulateBuilder<arrow::Type::BOOL>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto bool_builder = static_cast<arrow::BooleanBuilder*>(builder);
-  PARQUET_THROW_NOT_OK(bool_builder->AppendValues((uint8_t*)kG(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_uint8 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.uint8_null ^ kG( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( bool_builder->AppendValues( ( uint8_t* )kG( k_array ), k_array->n, null_bitmap ) );
+  }
+  else {
+    PARQUET_THROW_NOT_OK(bool_builder->AppendValues((uint8_t*)kG(k_array), k_array->n));
+  }
 }
 
 template<>
 void PopulateBuilder<arrow::Type::UINT8>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto uint8_builder = static_cast<arrow::UInt8Builder*>(builder);
-  PARQUET_THROW_NOT_OK(uint8_builder->AppendValues((uint8_t*)kG(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_uint8 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.uint8_null ^ kG( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( uint8_builder->AppendValues( ( uint8_t* )kG( k_array ), k_array->n, null_bitmap ) );
+  }
+  else {
+    PARQUET_THROW_NOT_OK(uint8_builder->AppendValues((uint8_t*)kG(k_array), k_array->n));
+  }
 }
 
 template<>
 void PopulateBuilder<arrow::Type::INT8>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto int8_builder = static_cast<arrow::Int8Builder*>(builder);
-  PARQUET_THROW_NOT_OK(int8_builder->AppendValues((int8_t*)kG(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_int8 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.int8_null ^ kG( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( int8_builder->AppendValues( ( int8_t* )kG( k_array ), k_array->n, null_bitmap ) );
+  }
+  else {
+    PARQUET_THROW_NOT_OK(int8_builder->AppendValues((int8_t*)kG(k_array), k_array->n));
+  }
 }
 
 template<>
 void PopulateBuilder<arrow::Type::UINT16>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto uint16_builder = static_cast<arrow::UInt16Builder*>(builder);
-  PARQUET_THROW_NOT_OK(uint16_builder->AppendValues((uint16_t*)kH(k_array), k_array->n));
-  arrow::Status s;
+  if( type_overrides.null_mapping.have_uint16 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.uint16_null ^ kH( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( uint16_builder->AppendValues( ( uint16_t* )kH( k_array ), k_array->n, null_bitmap ) );
+  }
+  else {
+    PARQUET_THROW_NOT_OK(uint16_builder->AppendValues((uint16_t*)kH(k_array), k_array->n));
+  }
 }
 
 template<>
@@ -479,7 +528,16 @@ template<>
 void PopulateBuilder<arrow::Type::UINT32>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto uint32_builder = static_cast<arrow::UInt32Builder*>(builder);
-  PARQUET_THROW_NOT_OK(uint32_builder->AppendValues((uint32_t*)kI(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_uint32 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.uint32_null ^ kI( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( uint32_builder->AppendValues( ( uint32_t* )kI( k_array ), k_array->n, null_bitmap ) );
+  }
+  else{
+    PARQUET_THROW_NOT_OK(uint32_builder->AppendValues((uint32_t*)kI(k_array), k_array->n));
+  }
 }
 
 template<>
@@ -502,36 +560,80 @@ template<>
 void PopulateBuilder<arrow::Type::UINT64>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto uint64_builder = static_cast<arrow::UInt64Builder*>(builder);
-  PARQUET_THROW_NOT_OK(uint64_builder->AppendValues((uint64_t*)kJ(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_uint64 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.uint64_null ^ kI( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( uint64_builder->AppendValues( ( uint64_t* )kI( k_array ), k_array->n, null_bitmap ) );
+  }
+  else{
+    PARQUET_THROW_NOT_OK(uint64_builder->AppendValues((uint64_t*)kJ(k_array), k_array->n));
+  }
 }
 
 template<>
 void PopulateBuilder<arrow::Type::INT64>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto int64_builder = static_cast<arrow::Int64Builder*>(builder);
-  PARQUET_THROW_NOT_OK(int64_builder->AppendValues((int64_t*)kJ(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_int64 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.int64_null ^ kI( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( int64_builder->AppendValues( ( int64_t* )kI( k_array ), k_array->n, null_bitmap ) );
+  }
+  else{
+    PARQUET_THROW_NOT_OK(int64_builder->AppendValues((int64_t*)kJ(k_array), k_array->n));
+  }
 }
 
 template<>
 void PopulateBuilder<arrow::Type::HALF_FLOAT>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
-  arrow::HalfFloatType hft;
   auto hfl_builder = static_cast<arrow::HalfFloatBuilder*>(builder);
-  PARQUET_THROW_NOT_OK(hfl_builder->AppendValues((uint16_t*)kH(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_float16 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.float16_null ^ kH( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( hfl_builder->AppendValues( ( uint16_t* )kH( k_array ), k_array->n, null_bitmap ) );
+  }
+  else {
+    PARQUET_THROW_NOT_OK(hfl_builder->AppendValues((uint16_t*)kH(k_array), k_array->n));
+  }
 }
 
 template<>
 void PopulateBuilder<arrow::Type::FLOAT>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto fl_builder = static_cast<arrow::FloatBuilder*>(builder);
-  PARQUET_THROW_NOT_OK(fl_builder->AppendValues(kE(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_float32 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = is_equal( type_overrides.null_mapping.float32_null, kE( k_array )[i] );
+    }
+    PARQUET_THROW_NOT_OK( fl_builder->AppendValues( kE( k_array ), k_array->n, null_bitmap ) );
+  }
+  else {
+    PARQUET_THROW_NOT_OK(fl_builder->AppendValues(kE(k_array), k_array->n));
+  }
 }
 
 template<>
 void PopulateBuilder<arrow::Type::DOUBLE>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto dbl_builder = static_cast<arrow::DoubleBuilder*>(builder);
-  PARQUET_THROW_NOT_OK(dbl_builder->AppendValues(kF(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_float64 ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = is_equal( type_overrides.null_mapping.float64_null, kF( k_array )[i] );
+    }
+    PARQUET_THROW_NOT_OK( dbl_builder->AppendValues( kF( k_array ), k_array->n, null_bitmap ) );
+  }
+  else {
+    PARQUET_THROW_NOT_OK(dbl_builder->AppendValues(kF(k_array), k_array->n));
+  }
 }
 
 template<>
@@ -607,7 +709,14 @@ void PopulateBuilder<arrow::Type::BINARY>(shared_ptr<arrow::DataType> datatype, 
   for (auto i = 0; i < k_array->n; ++i) {
     K bin_data = kK(k_array)[i];
     TYPE_CHECK_ITEM(bin_data->t != KG, datatype->ToString(), KG, bin_data->t);
-    PARQUET_THROW_NOT_OK(bin_builder->Append(kG(bin_data), bin_data->n));
+    if( type_overrides.null_mapping.have_binary
+        && type_overrides.null_mapping.binary_null.length() == bin_data->n
+        && !type_overrides.null_mapping.binary_null.compare( 0, bin_data->n, kG( bin_data ), bin_data->n ) ){
+      PARQUET_THROW_NOT_OK( bin_builder->AppendNull() );
+    }
+    else{
+      PARQUET_THROW_NOT_OK(bin_builder->Append(kG(bin_data), bin_data->n));
+    }
   }
 }
 
@@ -618,7 +727,14 @@ void PopulateBuilder<arrow::Type::LARGE_BINARY>(shared_ptr<arrow::DataType> data
   for (auto i = 0; i < k_array->n; ++i) {
     K bin_data = kK(k_array)[i];
     TYPE_CHECK_ITEM(bin_data->t != KG, datatype->ToString(), KG, bin_data->t);
-    PARQUET_THROW_NOT_OK(bin_builder->Append(kG(bin_data), bin_data->n));
+    if( type_overrides.null_mapping.have_large_binary
+        && type_overrides.null_mapping.large_binary_null.length() == bin_data->n
+        && !type_overrides.null_mapping.large_binary_null.compare( 0, bin_data->n, kG( bin_data ), bin_data->n ) ){
+      PARQUET_THROW_NOT_OK( bin_builder->AppendNull() );
+    }
+    else{
+      PARQUET_THROW_NOT_OK(bin_builder->Append(kG(bin_data), bin_data->n));
+    }
   }
 }
 
@@ -645,8 +761,15 @@ void PopulateBuilder<arrow::Type::DATE32>(shared_ptr<arrow::DataType> datatype, 
 {
   TemporalConversion tc(datatype);
   auto d32_builder = static_cast<arrow::Date32Builder*>(builder);
-  for (auto i = 0; i < k_array->n; ++i)
-    PARQUET_THROW_NOT_OK(d32_builder->Append(tc.KdbToArrow(kI(k_array)[i])));
+  for (auto i = 0; i < k_array->n; ++i){
+    if( type_overrides.null_mapping.have_date32
+        && type_overrides.null_mapping.date32_null == kI( k_array )[i] ){
+      PARQUET_THROW_NOT_OK( d32_builder->AppendNull() );
+    }
+    else{
+      PARQUET_THROW_NOT_OK(d32_builder->Append(tc.KdbToArrow(kI(k_array)[i])));
+    }
+  }
 }
 
 template<>
@@ -655,7 +778,13 @@ void PopulateBuilder<arrow::Type::DATE64>(shared_ptr<arrow::DataType> datatype, 
   TemporalConversion tc(datatype);
   auto d64_builder = static_cast<arrow::Date64Builder*>(builder);
   for (auto i = 0; i < k_array->n; ++i)
-    PARQUET_THROW_NOT_OK(d64_builder->Append(tc.KdbToArrow(kJ(k_array)[i])));
+    if( type_overrides.null_mapping.have_date64
+        && type_overrides.null_mapping.date64_null == kJ( k_array )[i] ){
+      PARQUET_THROW_NOT_OK( d64_builder->AppendNull() );
+    }
+    else{
+      PARQUET_THROW_NOT_OK(d64_builder->Append(tc.KdbToArrow(kJ(k_array)[i])));
+    }
 }
 
 template<>
@@ -725,15 +854,31 @@ template<>
 void PopulateBuilder<arrow::Type::INTERVAL_MONTHS>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto month_builder = static_cast<arrow::MonthIntervalBuilder*>(builder);
-  PARQUET_THROW_NOT_OK(month_builder->AppendValues((int32_t*)kI(k_array), k_array->n));
+  if( type_overrides.null_mapping.have_month_interval ){
+    std::vector<bool> null_bitmap( k_array->n );
+    for( auto i = 0ll; i < k_array->n; ++i ){
+      null_bitmap[i] = type_overrides.null_mapping.month_interval_null ^ kI( k_array )[i];
+    }
+    PARQUET_THROW_NOT_OK( month_builder->AppendValues( ( int32_t* )kI( k_array ), k_array->n, null_bitmap ) );
+  }
+  else{
+    PARQUET_THROW_NOT_OK(month_builder->AppendValues((int32_t*)kI(k_array), k_array->n));
+  }
 }
 
 template<>
 void PopulateBuilder<arrow::Type::INTERVAL_DAY_TIME>(shared_ptr<arrow::DataType> datatype, K k_array, arrow::ArrayBuilder* builder, TypeMappingOverride& type_overrides)
 {
   auto dt_builder = static_cast<arrow::DayTimeIntervalBuilder*>(builder);
-  for (auto i = 0; i < k_array->n; ++i)
-    PARQUET_THROW_NOT_OK(dt_builder->Append(KTimespan_DayTimeInterval(kJ(k_array)[i])));
+  for (auto i = 0; i < k_array->n; ++i){
+    if( type_overrides.null_mapping.have_day_time_interval
+        && type_overrides.null_mapping.day_time_interval_null == kJ( k_array )[i] ){
+      PARQUET_THROW_NOT_OK( dt_builder->AppendNull() );
+    }
+    else{
+      PARQUET_THROW_NOT_OK(dt_builder->Append(KTimespan_DayTimeInterval(kJ(k_array)[i])));
+    }
+  }
 }
 
 template<>

--- a/src/ArrayWriter.cpp
+++ b/src/ArrayWriter.cpp
@@ -451,7 +451,7 @@ void PopulateBuilder<arrow::Type::BOOL>(shared_ptr<arrow::DataType> datatype, K 
   if( type_overrides.null_mapping.have_boolean ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.boolean_null != kG( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.boolean_null != static_cast<bool>( kG( k_array )[i] );
     }
     PARQUET_THROW_NOT_OK( bool_builder->AppendValues( ( uint8_t* )kG( k_array ), k_array->n, null_bitmap ) );
   }
@@ -467,7 +467,7 @@ void PopulateBuilder<arrow::Type::UINT8>(shared_ptr<arrow::DataType> datatype, K
   if( type_overrides.null_mapping.have_uint8 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.uint8_null != kG( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.uint8_null != static_cast<uint8_t>( kG( k_array )[i] );
     }
     PARQUET_THROW_NOT_OK( uint8_builder->AppendValues( ( uint8_t* )kG( k_array ), k_array->n, null_bitmap ) );
   }
@@ -499,7 +499,7 @@ void PopulateBuilder<arrow::Type::UINT16>(shared_ptr<arrow::DataType> datatype, 
   if( type_overrides.null_mapping.have_uint16 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.uint16_null != kH( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.uint16_null != static_cast<uint16_t>( kH( k_array )[i] );
     }
     PARQUET_THROW_NOT_OK( uint16_builder->AppendValues( ( uint16_t* )kH( k_array ), k_array->n, null_bitmap ) );
   }
@@ -595,7 +595,7 @@ void PopulateBuilder<arrow::Type::HALF_FLOAT>(shared_ptr<arrow::DataType> dataty
   if( type_overrides.null_mapping.have_float16 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.float16_null != kH( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.float16_null != static_cast<uint16_t>( kH( k_array )[i] );
     }
     PARQUET_THROW_NOT_OK( hfl_builder->AppendValues( ( uint16_t* )kH( k_array ), k_array->n, null_bitmap ) );
   }

--- a/src/ArrayWriter.cpp
+++ b/src/ArrayWriter.cpp
@@ -611,7 +611,7 @@ void PopulateBuilder<arrow::Type::FLOAT>(shared_ptr<arrow::DataType> datatype, K
   if( type_overrides.null_mapping.have_float32 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = is_equal( type_overrides.null_mapping.float32_null, kE( k_array )[i] );
+      null_bitmap[i] = !is_equal( type_overrides.null_mapping.float32_null, kE( k_array )[i] );
     }
     PARQUET_THROW_NOT_OK( fl_builder->AppendValues( kE( k_array ), k_array->n, null_bitmap ) );
   }
@@ -627,7 +627,7 @@ void PopulateBuilder<arrow::Type::DOUBLE>(shared_ptr<arrow::DataType> datatype, 
   if( type_overrides.null_mapping.have_float64 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = is_equal( type_overrides.null_mapping.float64_null, kF( k_array )[i] );
+      null_bitmap[i] = !is_equal( type_overrides.null_mapping.float64_null, kF( k_array )[i] );
     }
     PARQUET_THROW_NOT_OK( dbl_builder->AppendValues( kF( k_array ), k_array->n, null_bitmap ) );
   }

--- a/src/ArrayWriter.cpp
+++ b/src/ArrayWriter.cpp
@@ -451,7 +451,7 @@ void PopulateBuilder<arrow::Type::BOOL>(shared_ptr<arrow::DataType> datatype, K 
   if( type_overrides.null_mapping.have_boolean ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.boolean_null ^ kG( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.boolean_null != kG( k_array )[i];
     }
     PARQUET_THROW_NOT_OK( bool_builder->AppendValues( ( uint8_t* )kG( k_array ), k_array->n, null_bitmap ) );
   }
@@ -467,7 +467,7 @@ void PopulateBuilder<arrow::Type::UINT8>(shared_ptr<arrow::DataType> datatype, K
   if( type_overrides.null_mapping.have_uint8 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.uint8_null ^ kG( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.uint8_null != kG( k_array )[i];
     }
     PARQUET_THROW_NOT_OK( uint8_builder->AppendValues( ( uint8_t* )kG( k_array ), k_array->n, null_bitmap ) );
   }
@@ -483,7 +483,7 @@ void PopulateBuilder<arrow::Type::INT8>(shared_ptr<arrow::DataType> datatype, K 
   if( type_overrides.null_mapping.have_int8 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.int8_null ^ kG( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.int8_null != kG( k_array )[i];
     }
     PARQUET_THROW_NOT_OK( int8_builder->AppendValues( ( int8_t* )kG( k_array ), k_array->n, null_bitmap ) );
   }
@@ -499,7 +499,7 @@ void PopulateBuilder<arrow::Type::UINT16>(shared_ptr<arrow::DataType> datatype, 
   if( type_overrides.null_mapping.have_uint16 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.uint16_null ^ kH( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.uint16_null != kH( k_array )[i];
     }
     PARQUET_THROW_NOT_OK( uint16_builder->AppendValues( ( uint16_t* )kH( k_array ), k_array->n, null_bitmap ) );
   }
@@ -531,7 +531,7 @@ void PopulateBuilder<arrow::Type::UINT32>(shared_ptr<arrow::DataType> datatype, 
   if( type_overrides.null_mapping.have_uint32 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.uint32_null ^ kI( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.uint32_null != static_cast<uint32_t>( kI( k_array )[i] );
     }
     PARQUET_THROW_NOT_OK( uint32_builder->AppendValues( ( uint32_t* )kI( k_array ), k_array->n, null_bitmap ) );
   }
@@ -563,7 +563,7 @@ void PopulateBuilder<arrow::Type::UINT64>(shared_ptr<arrow::DataType> datatype, 
   if( type_overrides.null_mapping.have_uint64 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.uint64_null ^ kJ( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.uint64_null != static_cast<uint64_t>( kJ( k_array )[i] );
     }
     PARQUET_THROW_NOT_OK( uint64_builder->AppendValues( ( uint64_t* )kJ( k_array ), k_array->n, null_bitmap ) );
   }
@@ -579,7 +579,7 @@ void PopulateBuilder<arrow::Type::INT64>(shared_ptr<arrow::DataType> datatype, K
   if( type_overrides.null_mapping.have_int64 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.int64_null ^ kJ( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.int64_null != kJ( k_array )[i];
     }
     PARQUET_THROW_NOT_OK( int64_builder->AppendValues( ( int64_t* )kJ( k_array ), k_array->n, null_bitmap ) );
   }
@@ -595,7 +595,7 @@ void PopulateBuilder<arrow::Type::HALF_FLOAT>(shared_ptr<arrow::DataType> dataty
   if( type_overrides.null_mapping.have_float16 ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.float16_null ^ kH( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.float16_null != kH( k_array )[i];
     }
     PARQUET_THROW_NOT_OK( hfl_builder->AppendValues( ( uint16_t* )kH( k_array ), k_array->n, null_bitmap ) );
   }
@@ -894,7 +894,7 @@ void PopulateBuilder<arrow::Type::INTERVAL_MONTHS>(shared_ptr<arrow::DataType> d
   if( type_overrides.null_mapping.have_month_interval ){
     std::vector<bool> null_bitmap( k_array->n );
     for( auto i = 0ll; i < k_array->n; ++i ){
-      null_bitmap[i] = type_overrides.null_mapping.month_interval_null ^ kI( k_array )[i];
+      null_bitmap[i] = type_overrides.null_mapping.month_interval_null != kI( k_array )[i];
     }
     PARQUET_THROW_NOT_OK( month_builder->AppendValues( ( int32_t* )kI( k_array ), k_array->n, null_bitmap ) );
   }

--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -249,8 +249,8 @@ inline const ETraits<arrow::Type::type>::Names ETraits<arrow::Type::type>::names
   , { arrow::Type::DATE32, Options::NM_DATE_32 }
   , { arrow::Type::DATE64, Options::NM_DATE_64 }
   , { arrow::Type::TIMESTAMP, Options::NM_TIMESTAMP }
-  , { arrow::Type::DATE32, Options::NM_DATE_32 }
-  , { arrow::Type::DATE64, Options::NM_DATE_64 }
+  , { arrow::Type::TIME32, Options::NM_TIME_32 }
+  , { arrow::Type::TIME64, Options::NM_TIME_64 }
   , { arrow::Type::DECIMAL, Options::NM_DECIMAL }
   , { arrow::Type::DURATION, Options::NM_DURATION }
   , { arrow::Type::INTERVAL_MONTHS, Options::NM_MONTH_INTERVAL }
@@ -390,13 +390,29 @@ private:
         null_mapping_options.large_string_null.assign( (char*)kC( value ), value->n );
         null_mapping_options.have_large_string = true;
       }
+      else if( ETraits<NM>::name( NM::BINARY ) == key && KG == value->t ){
+        null_mapping_options.binary_null.assign( kG( value ), value->n );
+        null_mapping_options.have_binary = true;
+      }
       else if( ETraits<NM>::name( NM::BINARY ) == key && KC == value->t ){
         null_mapping_options.binary_null.assign( kC( value ), value->n );
         null_mapping_options.have_binary = true;
       }
+      else if( ETraits<NM>::name( NM::LARGE_BINARY ) == key && KG == value->t ){
+        null_mapping_options.large_binary_null.assign( kG( value ), value->n );
+        null_mapping_options.have_large_binary = true;
+      }
       else if( ETraits<NM>::name( NM::LARGE_BINARY ) == key && KC == value->t ){
         null_mapping_options.large_binary_null.assign( kC( value ), value->n );
         null_mapping_options.have_large_binary = true;
+      }
+      else if( ETraits<NM>::name( NM::FIXED_SIZE_BINARY ) == key && -UU == value->t ){
+        null_mapping_options.fixed_binary_null.assign( &kU( value )->g[0], sizeof( U ) );
+        null_mapping_options.have_fixed_binary = true;
+      }
+      else if( ETraits<NM>::name( NM::FIXED_SIZE_BINARY ) == key && KG == value->t ){
+        null_mapping_options.fixed_binary_null.assign( kG( value ), value->n );
+        null_mapping_options.have_fixed_binary = true;
       }
       else if( ETraits<NM>::name( NM::FIXED_SIZE_BINARY ) == key && KC == value->t ){
         null_mapping_options.fixed_binary_null.assign( kC( value ), value->n );

--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -76,7 +76,6 @@ namespace Options
   const std::string NULL_MAPPING = "NULL_MAPPING";
 
   // Null mapping options
-  const std::string NM_NA = "na";
   const std::string NM_BOOLEAN = "bool";
   const std::string NM_UINT_8 = "uint8";
   const std::string NM_INT_8 = "int8";
@@ -119,7 +118,6 @@ namespace Options
 
   struct NullMapping
   {
-      bool have_na;
       bool have_boolean;
       bool have_uint8;
       bool have_int8;
@@ -149,7 +147,6 @@ namespace Options
 
       using Binary = std::basic_string<unsigned char>;
 
-      void* na_null = nullptr;
       bool boolean_null;
 
       uint8_t uint8_null;
@@ -184,8 +181,8 @@ namespace Options
       int32_t month_interval_null;
       int64_t day_time_interval_null;
 
-      template<arrow::Type::type TypeId = arrow::Type::NA>
-      inline auto GetOption() const { return std::make_pair( true, na_null );}
+      template<arrow::Type::type TypeId>
+      inline auto GetOption() const;
   };
 
   template<> inline auto NullMapping::GetOption<arrow::Type::BOOL>() const{ return std::make_pair( have_boolean, boolean_null ); }
@@ -218,8 +215,7 @@ namespace Options
 
 template<>
 inline const ETraits<arrow::Type::type>::Options ETraits<arrow::Type::type>::options{
-    { arrow::Type::NA, arrowkdb::Options::NM_NA }
-  , { arrow::Type::BOOL, arrowkdb::Options::NM_BOOLEAN }
+    { arrow::Type::BOOL, arrowkdb::Options::NM_BOOLEAN }
   , { arrow::Type::UINT8, arrowkdb::Options::NM_UINT_8 }
   , { arrow::Type::INT8, arrowkdb::Options::NM_INT_8 }
   , { arrow::Type::UINT16, arrowkdb::Options::NM_UINT_16 }
@@ -444,8 +440,7 @@ public:
   template<arrow::Type::type TypeId = arrow::Type::NA>
   auto GetNullMappingOption() const { return null_mapping_options.GetOption<TypeId>(); }
 
-  void GetNullMappingOptions( Options::NullMapping& null_mapping ) const
-  {
+  void GetNullMappingOptions( Options::NullMapping& null_mapping ) const{
       null_mapping = null_mapping_options;
   }
 

--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -58,7 +58,7 @@ namespace Options
 
   // Null mapping options
   const std::string NM_NA = "na";
-  const std::string NM_BOOLEAN = "boolean";
+  const std::string NM_BOOLEAN = "bool";
   const std::string NM_UINT_8 = "uint8";
   const std::string NM_INT_8 = "int8";
   const std::string NM_UINT_16 = "uint16";

--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -23,7 +23,7 @@ constexpr auto toUType( E enumerator ) noexcept
 template< typename E >
 struct ETraits
 {
-    using Names = std::map< E, std::string >;
+    using Names = std::map<E, std::string>;
 
     static std::string name( E enumerator )
     {
@@ -33,7 +33,7 @@ struct ETraits
             return it->second;
         }
 
-        return "unknown";
+        return "UNKNOWN";
     }
 
     static std::string name( int index ) { return name( static_cast<E>( index ) ); }
@@ -57,10 +57,27 @@ namespace Options
   const std::string NULL_MAPPING = "NULL_MAPPING";
 
   // Null mapping options
+  const std::string NM_NA = "na";
+  const std::string NM_BOOLEAN = "boolean";
+  const std::string NM_UINT_8 = "uint8";
+  const std::string NM_INT_8 = "int8";
+  const std::string NM_UINT_16 = "uint16";
   const std::string NM_INT_16 = "int16";
+  const std::string NM_UINT_32 = "uint32";
   const std::string NM_INT_32 = "int32";
+  const std::string NM_UINT_64 = "uint64";
+  const std::string NM_INT_64 = "int64";
+  const std::string NM_FLOAT_16 = "float16";
+  const std::string NM_FLOAT_32 = "float32";
+  const std::string NM_FLOAT_64 = "float64";
   const std::string NM_STRING = "string";
   const std::string NM_LARGE_STRING = "large_string";
+  const std::string NM_BINARY = "binary";
+  const std::string NM_LARGE_BINARY = "large_binary";
+  const std::string NM_DATE_32 = "date32";
+  const std::string NM_DATE_64 = "date64";
+  const std::string NM_MONTH_INTERVAL = "month_interval";
+  const std::string NM_DAY_TIME_INTERVAL = "day_time_interval";
 
   const static std::set<std::string> int_options = {
     PARQUET_CHUNK_SIZE,
@@ -75,38 +92,133 @@ namespace Options
     NULL_MAPPING,
   };
   const static std::set<std::string> null_mapping_options = {
-    NM_INT_16,
-    NM_INT_32,
-    NM_STRING,
-    NM_LARGE_STRING
+      NM_NA
+    , NM_BOOLEAN
+    , NM_UINT_8
+    , NM_INT_8
+    , NM_UINT_16
+    , NM_INT_16
+    , NM_UINT_32
+    , NM_INT_32
+    , NM_UINT_64
+    , NM_INT_64
+    , NM_FLOAT_16
+    , NM_FLOAT_32
+    , NM_FLOAT_64
+    , NM_STRING
+    , NM_LARGE_STRING
+    , NM_BINARY
+    , NM_LARGE_BINARY
+    , NM_DATE_32
+    , NM_DATE_64
+    , NM_MONTH_INTERVAL
+    , NM_DAY_TIME_INTERVAL
   };
 
   struct NullMapping
   {
       enum class Type: int{
-            INT_16
+            NA
+          , BOOLEAN
+          , UINT_8
+          , INT_8
+          , UINT_16
+          , INT_16
+          , UINT_32
           , INT_32
+          , UINT_64
+          , INT_64
+          , FLOAT_16
+          , FLOAT_32
+          , FLOAT_64
           , STRING
           , LARGE_STRING
+          , BINARY
+          , LARGE_BINARY
+          , DATE_32
+          , DATE_64
+          , MONTH_INTERVAL
+          , DAY_TIME_INTERVAL
       };
 
+      bool have_na;
+      bool have_boolean;
+      bool have_uint8;
+      bool have_int8;
+      bool have_uint16;
       bool have_int16;
-      int16_t int16_null;
+      bool have_uint32;
       bool have_int32;
-      int32_t int32_null;
+      bool have_uint64;
+      bool have_int64;
+      bool have_float16;
+      bool have_float32;
+      bool have_float64;
       bool have_string;
-      std::string string_null;
       bool have_large_string;
+      bool have_binary;
+      bool have_large_binary;
+      bool have_date32;
+      bool have_date64;
+      bool have_month_interval;
+      bool have_day_time_interval;
+
+      using Binary = std::basic_string<unsigned char>;
+
+      void* na_null = nullptr;
+      bool boolean_null;
+
+      uint8_t uint8_null;
+      int8_t int8_null;
+
+      uint16_t uint16_null;
+      int16_t int16_null;
+
+      uint32_t uint32_null;
+      int32_t int32_null;
+
+      uint64_t uint64_null;
+      int64_t int64_null;
+
+      uint16_t float16_null;
+      float float32_null;
+      double float64_null;
+
+      std::string string_null;
       std::string large_string_null;
+      Binary binary_null;
+      Binary large_binary_null;
+
+      int32_t date32_null;
+      int64_t date64_null;
+      int32_t month_interval_null;
+      int64_t day_time_interval_null;
   };
 }
 
 template<>
 inline const ETraits< Options::NullMapping::Type >::Names ETraits< Options::NullMapping::Type >::names {
-    { Options::NullMapping::Type::INT_16, Options::NM_INT_16 }
+    { Options::NullMapping::Type::NA, Options::NM_NA }
+  , { Options::NullMapping::Type::BOOLEAN, Options::NM_BOOLEAN }
+  , { Options::NullMapping::Type::UINT_8, Options::NM_UINT_8 }
+  , { Options::NullMapping::Type::INT_8, Options::NM_INT_8 }
+  , { Options::NullMapping::Type::UINT_16, Options::NM_UINT_16 }
+  , { Options::NullMapping::Type::INT_16, Options::NM_INT_16 }
+  , { Options::NullMapping::Type::UINT_32, Options::NM_UINT_32 }
   , { Options::NullMapping::Type::INT_32, Options::NM_INT_32 }
+  , { Options::NullMapping::Type::UINT_64, Options::NM_UINT_64 }
+  , { Options::NullMapping::Type::INT_64, Options::NM_INT_64 }
+  , { Options::NullMapping::Type::FLOAT_16, Options::NM_FLOAT_16 }
+  , { Options::NullMapping::Type::FLOAT_32, Options::NM_FLOAT_32 }
+  , { Options::NullMapping::Type::FLOAT_64, Options::NM_FLOAT_64 }
   , { Options::NullMapping::Type::STRING, Options::NM_STRING }
   , { Options::NullMapping::Type::LARGE_STRING, Options::NM_LARGE_STRING }
+  , { Options::NullMapping::Type::BINARY, Options::NM_BINARY }
+  , { Options::NullMapping::Type::LARGE_BINARY, Options::NM_LARGE_BINARY }
+  , { Options::NullMapping::Type::DATE_32, Options::NM_DATE_32 }
+  , { Options::NullMapping::Type::DATE_64, Options::NM_DATE_64 }
+  , { Options::NullMapping::Type::MONTH_INTERVAL, Options::NM_MONTH_INTERVAL }
+  , { Options::NullMapping::Type::DAY_TIME_INTERVAL, Options::NM_DAY_TIME_INTERVAL }
 };
 
 // Helper class for reading dictionary of options
@@ -182,13 +294,53 @@ private:
         throw InvalidOption(("Unsupported NULL_MAPPING option '" + key + "'").c_str());
       }
       K value = kK( values )[i];
-      if( ETraits<NM>::name( NM::INT_16 ) == key && -KH == value->t ){
+      if( ETraits<NM>::name( NM::BOOLEAN ) == key && -KG == value->t ){
+        null_mapping_options.boolean_null = value->g;
+        null_mapping_options.have_boolean = true;
+      }
+      else if( ETraits<NM>::name( NM::UINT_8 ) == key && -KG == value->t ){
+        null_mapping_options.uint8_null = value->g;
+        null_mapping_options.have_uint8 = true;
+      }
+      else if( ETraits<NM>::name( NM::INT_8 ) == key && -KG == value->t ){
+        null_mapping_options.int8_null = value->g;
+        null_mapping_options.have_int8 = true;
+      }
+      else if( ETraits<NM>::name( NM::UINT_16 ) == key && -KH == value->t ){
+        null_mapping_options.uint16_null = value->h;
+        null_mapping_options.have_uint16 = true;
+      }
+      else if( ETraits<NM>::name( NM::INT_16 ) == key && -KH == value->t ){
         null_mapping_options.int16_null = value->h;
         null_mapping_options.have_int16 = true;
+      }
+      else if( ETraits<NM>::name( NM::UINT_32 ) == key && -KI == value->t ){
+        null_mapping_options.uint32_null = value->i;
+        null_mapping_options.have_uint32 = true;
       }
       else if( ETraits<NM>::name( NM::INT_32 ) == key && -KI == value->t ){
         null_mapping_options.int32_null = value->i;
         null_mapping_options.have_int32 = true;
+      }
+      else if( ETraits<NM>::name( NM::UINT_64 ) == key && -KJ == value->t ){
+        null_mapping_options.uint64_null = value->j;
+        null_mapping_options.have_uint64 = true;
+      }
+      else if( ETraits<NM>::name( NM::INT_64 ) == key && -KJ == value->t ){
+        null_mapping_options.int64_null = value->j;
+        null_mapping_options.have_int64 = true;
+      }
+      else if( ETraits<NM>::name( NM::FLOAT_16 ) == key && -KH == value->t ){
+        null_mapping_options.float16_null = value->h;
+        null_mapping_options.have_float16 = true;
+      }
+      else if( ETraits<NM>::name( NM::FLOAT_32 ) == key && -KE == value->t ){
+        null_mapping_options.float32_null = value->e;
+        null_mapping_options.have_float32 = true;
+      }
+      else if( ETraits<NM>::name( NM::FLOAT_64 ) == key && -KF == value->t ){
+        null_mapping_options.float64_null = value->f;
+        null_mapping_options.have_float64 = true;
       }
       else if( ETraits<NM>::name( NM::STRING ) == key && KC == value->t ){
         null_mapping_options.string_null.assign( (char*)kC( value ), value->n );
@@ -197,6 +349,30 @@ private:
       else if( ETraits<NM>::name( NM::LARGE_STRING ) == key && KC == value->t ){
         null_mapping_options.large_string_null.assign( (char*)kC( value ), value->n );
         null_mapping_options.have_large_string = true;
+      }
+      else if( ETraits<NM>::name( NM::BINARY ) == key && KC == value->t ){
+        null_mapping_options.binary_null.assign( kC( value ), value->n );
+        null_mapping_options.have_binary = true;
+      }
+      else if( ETraits<NM>::name( NM::LARGE_BINARY ) == key && KC == value->t ){
+        null_mapping_options.large_binary_null.assign( kC( value ), value->n );
+        null_mapping_options.have_large_binary = true;
+      }
+      else if( ETraits<NM>::name( NM::DATE_32 ) == key && -KI == value->t ){
+        null_mapping_options.date32_null = value->i;
+        null_mapping_options.have_date32 = true;
+      }
+      else if( ETraits<NM>::name( NM::DATE_64 ) == key && -KJ == value->t ){
+        null_mapping_options.date64_null = value->j;
+        null_mapping_options.have_date64 = true;
+      }
+      else if( ETraits<NM>::name( NM::MONTH_INTERVAL ) == key && -KI == value->t ){
+        null_mapping_options.month_interval_null = value->i;
+        null_mapping_options.have_month_interval = true;
+      }
+      else if( ETraits<NM>::name( NM::DAY_TIME_INTERVAL ) == key && -KJ == value->t ){
+        null_mapping_options.day_time_interval_null = value->j;
+        null_mapping_options.have_day_time_interval = true;
       }
       else if( 101 == value->t ){
         // Ignore generic null, which may be used here to ensure mixed list of options
@@ -310,8 +486,12 @@ public:
     }
   }
 
-  template<Options::NullMapping::Type TypeId>
-  auto GetNullMappingOption( bool& result );
+  template<Options::NullMapping::Type TypeId = Options::NullMapping::Type::NA>
+  auto GetNullMappingOption( bool& result ) {
+      result = true;
+
+      return null_mapping_options.na_null;
+  }
 
   void GetNullMappingOptions( Options::NullMapping& null_mapping ) const
   {
@@ -342,36 +522,125 @@ public:
 };
 
 template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_16>( bool& result )
-{
-    result = null_mapping_options.have_int16;
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::BOOLEAN>( bool& result ){
+    result = null_mapping_options.have_boolean;
+    return null_mapping_options.boolean_null;
+}
 
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::UINT_8>( bool& result ){
+    result = null_mapping_options.have_uint8;
+    return null_mapping_options.uint8_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_8>( bool& result ){
+    result = null_mapping_options.have_int8;
+    return null_mapping_options.int8_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::UINT_16>( bool& result ){
+    result = null_mapping_options.have_uint16;
+    return null_mapping_options.uint16_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_16>( bool& result ){
+    result = null_mapping_options.have_int16;
     return null_mapping_options.int16_null;
 }
 
 template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_32>( bool& result )
-{
-    result = null_mapping_options.have_int32;
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::UINT_32>( bool& result ){
+    result = null_mapping_options.have_uint32;
+    return null_mapping_options.uint32_null;
+}
 
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_32>( bool& result ){
+    result = null_mapping_options.have_int32;
     return null_mapping_options.int32_null;
 }
 
 template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::STRING>( bool& result )
-{
-    result = null_mapping_options.have_string;
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::UINT_64>( bool& result ){
+    result = null_mapping_options.have_uint64;
+    return null_mapping_options.uint64_null;
+}
 
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_64>( bool& result ){
+    result = null_mapping_options.have_int64;
+    return null_mapping_options.int64_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::FLOAT_16>( bool& result ){
+    result = null_mapping_options.have_float16;
+    return null_mapping_options.float16_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::FLOAT_32>( bool& result ){
+    result = null_mapping_options.have_float32;
+    return null_mapping_options.float32_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::FLOAT_64>( bool& result ){
+    result = null_mapping_options.have_float64;
+    return null_mapping_options.float64_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::STRING>( bool& result ){
+    result = null_mapping_options.have_string;
     return null_mapping_options.string_null;
 }
 
 template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::LARGE_STRING>( bool& result )
-{
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::LARGE_STRING>( bool& result ){
     result = null_mapping_options.have_large_string;
-
     return null_mapping_options.large_string_null;
 }
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::BINARY>( bool& result ){
+    result = null_mapping_options.have_binary;
+    return null_mapping_options.binary_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::LARGE_BINARY>( bool& result ){
+    result = null_mapping_options.have_large_binary;
+    return null_mapping_options.large_binary_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::DATE_32>( bool& result ){
+    result = null_mapping_options.have_date32;
+    return null_mapping_options.date32_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::DATE_64>( bool& result ){
+    result = null_mapping_options.have_date64;
+    return null_mapping_options.date64_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::MONTH_INTERVAL>( bool& result ){
+    result = null_mapping_options.have_month_interval;
+    return null_mapping_options.month_interval_null;
+}
+
+template<>
+inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::DAY_TIME_INTERVAL>( bool& result ){
+    result = null_mapping_options.have_day_time_interval;
+    return null_mapping_options.day_time_interval_null;
+}
+
 
 } // namespace arrowkdb
 } // namespace kx

--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -16,39 +16,48 @@ namespace kx {
 namespace arrowkdb {
 
 template<typename E>
-constexpr auto toUType( E enumerator ) noexcept
+constexpr auto toUType( E option ) noexcept
 {
-    return static_cast<std::underlying_type_t<E>>( enumerator );
+    return static_cast<std::underlying_type_t<E>>( option );
 }
 
 template< typename E >
 struct ETraits
 {
-    using Names = std::unordered_map<E, std::string>;
+    using Options = std::unordered_map<E, std::string>;
 
-    static std::string name( E enumerator ){
-        auto it = names.find( enumerator );
-        if( it != names.end() ){
+    static std::string mapping( E option ){
+        auto it = options.find( option );
+        if( it != options.end() ){
             return it->second;
         }
 
-        return "UNKNOWN";
+        return "unknown";
     }
 
-    static std::string name( int index ) { return name( static_cast<E>( index ) ); }
+    static std::string mapping( int option ) { return mapping( static_cast<E>( option ) ); }
 
-    static auto value( const std::string& name ){
-      auto it = std::find_if( names.begin(), names.end(), [&name]( const auto& value ){
-        return name == value.second;
+    static std::set<std::string> mappings(){
+        std::set<std::string> values;
+        transform( options.begin(), options.end(), std::inserter( values, end( values ) ), []( const auto& option ){
+            return option.second;
+        } );
+
+        return values;
+    }
+
+    static E option( const std::string& value ){
+      auto it = std::find_if( options.begin(), options.end(), [&value]( const auto& option ){
+        return value == option.second;
       } );
-      if( it != names.end() ){
+      if( it != options.end() ){
         return it->first;
       }
 
       return E( 0 );
     }
 
-    static const Names names;
+    static const Options options;
 };
 
 // Supported options
@@ -106,35 +115,6 @@ namespace Options
   };
   const static std::set<std::string> dict_options = {
     NULL_MAPPING,
-  };
-  const static std::set<std::string> null_mapping_options = {
-      NM_NA
-    , NM_BOOLEAN
-    , NM_UINT_8
-    , NM_INT_8
-    , NM_UINT_16
-    , NM_INT_16
-    , NM_UINT_32
-    , NM_INT_32
-    , NM_UINT_64
-    , NM_INT_64
-    , NM_FLOAT_16
-    , NM_FLOAT_32
-    , NM_FLOAT_64
-    , NM_STRING
-    , NM_LARGE_STRING
-    , NM_BINARY
-    , NM_LARGE_BINARY
-    , NM_FIXED_BINARY
-    , NM_DATE_32
-    , NM_DATE_64
-    , NM_TIMESTAMP
-    , NM_TIME_32
-    , NM_TIME_64
-    , NM_DECIMAL
-    , NM_DURATION
-    , NM_MONTH_INTERVAL
-    , NM_DAY_TIME_INTERVAL
   };
 
   struct NullMapping
@@ -205,7 +185,7 @@ namespace Options
       int64_t day_time_interval_null;
 
       template<arrow::Type::type TypeId = arrow::Type::NA>
-      auto GetOption() const { return std::make_pair( true, na_null );}
+      inline auto GetOption() const { return std::make_pair( true, na_null );}
   };
 
   template<> inline auto NullMapping::GetOption<arrow::Type::BOOL>() const{ return std::make_pair( have_boolean, boolean_null ); }
@@ -237,34 +217,34 @@ namespace Options
 } // namespace Options
 
 template<>
-inline const ETraits<arrow::Type::type>::Names ETraits<arrow::Type::type>::names{
-    { arrow::Type::NA, Options::NM_NA }
-  , { arrow::Type::BOOL, Options::NM_BOOLEAN }
-  , { arrow::Type::UINT8, Options::NM_UINT_8 }
-  , { arrow::Type::INT8, Options::NM_INT_8 }
-  , { arrow::Type::UINT16, Options::NM_UINT_16 }
-  , { arrow::Type::INT16, Options::NM_INT_16 }
-  , { arrow::Type::UINT32, Options::NM_UINT_32 }
-  , { arrow::Type::INT32, Options::NM_INT_32 }
-  , { arrow::Type::UINT64, Options::NM_UINT_64 }
-  , { arrow::Type::INT64, Options::NM_INT_64 }
-  , { arrow::Type::HALF_FLOAT, Options::NM_FLOAT_16 }
-  , { arrow::Type::FLOAT, Options::NM_FLOAT_32 }
-  , { arrow::Type::DOUBLE, Options::NM_FLOAT_64 }
-  , { arrow::Type::STRING, Options::NM_STRING }
-  , { arrow::Type::LARGE_STRING, Options::NM_LARGE_STRING }
-  , { arrow::Type::BINARY, Options::NM_BINARY }
-  , { arrow::Type::LARGE_BINARY, Options::NM_LARGE_BINARY }
-  , { arrow::Type::FIXED_SIZE_BINARY, Options::NM_FIXED_BINARY }
-  , { arrow::Type::DATE32, Options::NM_DATE_32 }
-  , { arrow::Type::DATE64, Options::NM_DATE_64 }
-  , { arrow::Type::TIMESTAMP, Options::NM_TIMESTAMP }
-  , { arrow::Type::TIME32, Options::NM_TIME_32 }
-  , { arrow::Type::TIME64, Options::NM_TIME_64 }
-  , { arrow::Type::DECIMAL, Options::NM_DECIMAL }
-  , { arrow::Type::DURATION, Options::NM_DURATION }
-  , { arrow::Type::INTERVAL_MONTHS, Options::NM_MONTH_INTERVAL }
-  , { arrow::Type::INTERVAL_DAY_TIME, Options::NM_DAY_TIME_INTERVAL }
+inline const ETraits<arrow::Type::type>::Options ETraits<arrow::Type::type>::options{
+    { arrow::Type::NA, arrowkdb::Options::NM_NA }
+  , { arrow::Type::BOOL, arrowkdb::Options::NM_BOOLEAN }
+  , { arrow::Type::UINT8, arrowkdb::Options::NM_UINT_8 }
+  , { arrow::Type::INT8, arrowkdb::Options::NM_INT_8 }
+  , { arrow::Type::UINT16, arrowkdb::Options::NM_UINT_16 }
+  , { arrow::Type::INT16, arrowkdb::Options::NM_INT_16 }
+  , { arrow::Type::UINT32, arrowkdb::Options::NM_UINT_32 }
+  , { arrow::Type::INT32, arrowkdb::Options::NM_INT_32 }
+  , { arrow::Type::UINT64, arrowkdb::Options::NM_UINT_64 }
+  , { arrow::Type::INT64, arrowkdb::Options::NM_INT_64 }
+  , { arrow::Type::HALF_FLOAT, arrowkdb::Options::NM_FLOAT_16 }
+  , { arrow::Type::FLOAT, arrowkdb::Options::NM_FLOAT_32 }
+  , { arrow::Type::DOUBLE, arrowkdb::Options::NM_FLOAT_64 }
+  , { arrow::Type::STRING, arrowkdb::Options::NM_STRING }
+  , { arrow::Type::LARGE_STRING, arrowkdb::Options::NM_LARGE_STRING }
+  , { arrow::Type::BINARY, arrowkdb::Options::NM_BINARY }
+  , { arrow::Type::LARGE_BINARY, arrowkdb::Options::NM_LARGE_BINARY }
+  , { arrow::Type::FIXED_SIZE_BINARY, arrowkdb::Options::NM_FIXED_BINARY }
+  , { arrow::Type::DATE32, arrowkdb::Options::NM_DATE_32 }
+  , { arrow::Type::DATE64, arrowkdb::Options::NM_DATE_64 }
+  , { arrow::Type::TIMESTAMP, arrowkdb::Options::NM_TIMESTAMP }
+  , { arrow::Type::TIME32, arrowkdb::Options::NM_TIME_32 }
+  , { arrow::Type::TIME64, arrowkdb::Options::NM_TIME_64 }
+  , { arrow::Type::DECIMAL, arrowkdb::Options::NM_DECIMAL }
+  , { arrow::Type::DURATION, arrowkdb::Options::NM_DURATION }
+  , { arrow::Type::INTERVAL_MONTHS, arrowkdb::Options::NM_MONTH_INTERVAL }
+  , { arrow::Type::INTERVAL_DAY_TIME, arrowkdb::Options::NM_DAY_TIME_INTERVAL }
 };
 
 // Helper class for reading dictionary of options
@@ -276,12 +256,6 @@ inline const ETraits<arrow::Type::type>::Names ETraits<arrow::Type::type>::names
 //                    0 of -KS|-KJ|XD|KC
 class KdbOptions
 {
-public:
-  template<arrow::Type::type TypeId>
-  inline void NullMappingOption( const std::string& key, K value );
-
-  using NullMappingHandler = void ( KdbOptions::* )( const std::string&, K );
-  using NullMappingHandlers = std::unordered_map<arrow::Type::type, NullMappingHandler>;
 private:
   Options::NullMapping null_mapping_options;
   std::map<std::string, std::string> string_options;
@@ -292,6 +266,8 @@ private:
   const std::set<std::string>& supported_dict_options;
   const std::set<std::string>& supported_null_mapping_options;
 
+  using NullMappingHandler = void ( KdbOptions::* )( const std::string&, K );
+  using NullMappingHandlers = std::unordered_map<arrow::Type::type, NullMappingHandler>;
   static const NullMappingHandlers null_mapping_handlers;
 private:
   const std::string ToUpper(std::string str) const
@@ -337,7 +313,7 @@ private:
         throw InvalidOption( "Unsupported KDB data type for NULL_MAPPING keys (expected=11h), type=" + std::to_string( keys->t ) + "h" );
     }
     if( 0 != values->t ){
-        throw InvalidOption( "Unsupported KDB data type for NULL_MAPPING values (extected=0h), type=" );
+        throw InvalidOption( "Unsupported KDB data type for NULL_MAPPING values (extected=0h), type=" + std::to_string( values->t ) + "h" );
     }
     for( auto i = 0ll; i < values->n; ++i ){
       const std::string key = ToLower( kS( keys )[i] );
@@ -345,8 +321,8 @@ private:
         throw InvalidOption( "Unsupported NULL_MAPPING option '" + key + "'" );
       }
       K value = kK( values )[i];
-      arrow::Type::type mapping = ETraits<arrow::Type::type>::value( key );
-      auto it = null_mapping_handlers.find( mapping );
+      auto option = ETraits<arrow::Type::type>::option( key );
+      auto it = null_mapping_handlers.find( option );
       if( it != null_mapping_handlers.end() ){
           ( this->*it->second )( key, value );
       }
@@ -429,7 +405,7 @@ public:
         , const std::set<std::string> supported_string_options_
         , const std::set<std::string> supported_int_options_
         , const std::set<std::string>& supported_dict_options_ = Options::dict_options
-        , const std::set<std::string>& supported_null_mapping_options_ = Options::null_mapping_options )
+        , const std::set<std::string>& supported_null_mapping_options_ = ETraits<arrow::Type::type>::mappings() )
     : null_mapping_options {0}
     , supported_string_options(supported_string_options_)
     , supported_int_options(supported_int_options_)
@@ -461,6 +437,9 @@ public:
       }
     }
   }
+
+  template<arrow::Type::type TypeId>
+  inline void HandleNullMapping( const std::string& key, K value );
 
   template<arrow::Type::type TypeId = arrow::Type::NA>
   auto GetNullMappingOption() const { return null_mapping_options.GetOption<TypeId>(); }
@@ -505,7 +484,7 @@ inline void null_mapping_error( const std::string& key, K value )
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::BOOL>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::BOOL>( const std::string& key, K value )
 {
   switch( value->t ){
   case -KB:
@@ -522,7 +501,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::BOOL>( const std::string&
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::UINT8>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::UINT8>( const std::string& key, K value )
 {
   if( -KG == value->t ){
     null_mapping_options.uint8_null = value->g;
@@ -534,7 +513,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::UINT8>( const std::string
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::INT8>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::INT8>( const std::string& key, K value )
 {
   if( -KG == value->t ){
     null_mapping_options.int8_null = value->g;
@@ -546,7 +525,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::INT8>( const std::string&
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::UINT16>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::UINT16>( const std::string& key, K value )
 {
   if( -KH == value->t ){
     null_mapping_options.uint16_null = value->h;
@@ -558,7 +537,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::UINT16>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::INT16>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::INT16>( const std::string& key, K value )
 {
   if( -KH == value->t ){
     null_mapping_options.int16_null = value->h;
@@ -570,7 +549,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::INT16>( const std::string
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::UINT32>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::UINT32>( const std::string& key, K value )
 {
   if( -KI == value->t ){
     null_mapping_options.uint32_null = value->i;
@@ -582,7 +561,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::UINT32>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::INT32>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::INT32>( const std::string& key, K value )
 {
   if( -KI == value->t ){
     null_mapping_options.int32_null = value->i;
@@ -594,7 +573,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::INT32>( const std::string
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::UINT64>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::UINT64>( const std::string& key, K value )
 {
   if( -KJ == value->t ){
     null_mapping_options.uint64_null = value->j;
@@ -606,7 +585,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::UINT64>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::INT64>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::INT64>( const std::string& key, K value )
 {
   if( -KJ == value->t ){
     null_mapping_options.int64_null = value->j;
@@ -618,7 +597,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::INT64>( const std::string
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::HALF_FLOAT>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::HALF_FLOAT>( const std::string& key, K value )
 {
   if( -KH == value->t ){
     null_mapping_options.float16_null = value->h;
@@ -630,7 +609,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::HALF_FLOAT>( const std::s
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::FLOAT>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::FLOAT>( const std::string& key, K value )
 {
   if( -KE == value->t ){
     null_mapping_options.float32_null = value->e;
@@ -642,7 +621,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::FLOAT>( const std::string
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::DOUBLE>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::DOUBLE>( const std::string& key, K value )
 {
   if( -KF == value->t ){
     null_mapping_options.float64_null = value->f;
@@ -654,10 +633,10 @@ inline void KdbOptions::NullMappingOption<arrow::Type::DOUBLE>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::STRING>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::STRING>( const std::string& key, K value )
 {
-  if( -KC == value->t ){
-    null_mapping_options.string_null.assign( (char*)kC( value ), value->n );
+  if( KC == value->t ){
+    null_mapping_options.string_null.assign( ( char* )kC( value ), value->n );
     null_mapping_options.have_string = true;
   }
   else{
@@ -666,10 +645,10 @@ inline void KdbOptions::NullMappingOption<arrow::Type::STRING>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::LARGE_STRING>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::LARGE_STRING>( const std::string& key, K value )
 {
-  if( -KC == value->t ){
-    null_mapping_options.large_string_null.assign( (char*)kC( value ), value->n );
+  if( KC == value->t ){
+    null_mapping_options.large_string_null.assign( ( char* )kC( value ), value->n );
     null_mapping_options.have_large_string = true;
   }
   else{
@@ -678,7 +657,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::LARGE_STRING>( const std:
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::BINARY>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::BINARY>( const std::string& key, K value )
 {
   switch( value->t ){
   case KG:
@@ -695,7 +674,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::BINARY>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::LARGE_BINARY>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::LARGE_BINARY>( const std::string& key, K value )
 {
   switch( value->t ){
   case KG:
@@ -712,7 +691,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::LARGE_BINARY>( const std:
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::FIXED_SIZE_BINARY>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::FIXED_SIZE_BINARY>( const std::string& key, K value )
 {
   switch( value->t ){
   case -UU:
@@ -733,7 +712,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::FIXED_SIZE_BINARY>( const
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::DATE32>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::DATE32>( const std::string& key, K value )
 {
   if( -KI == value->t ){
     null_mapping_options.date32_null = value->i;
@@ -745,7 +724,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::DATE32>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::DATE64>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::DATE64>( const std::string& key, K value )
 {
   if( -KJ == value->t ){
     null_mapping_options.date64_null = value->j;
@@ -757,7 +736,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::DATE64>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::TIMESTAMP>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::TIMESTAMP>( const std::string& key, K value )
 {
   if( -KJ == value->t ){
     null_mapping_options.timestamp_null = value->j;
@@ -769,7 +748,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::TIMESTAMP>( const std::st
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::TIME32>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::TIME32>( const std::string& key, K value )
 {
   if( -KI == value->t ){
     null_mapping_options.time32_null = value->i;
@@ -781,7 +760,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::TIME32>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::TIME64>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::TIME64>( const std::string& key, K value )
 {
   if( -KJ == value->t ){
     null_mapping_options.time64_null = value->j;
@@ -793,7 +772,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::TIME64>( const std::strin
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::DECIMAL>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::DECIMAL>( const std::string& key, K value )
 {
   if( -KF == value->t ){
     null_mapping_options.decimal_null = value->f;
@@ -805,7 +784,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::DECIMAL>( const std::stri
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::DURATION>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::DURATION>( const std::string& key, K value )
 {
   if( -KJ == value->t ){
     null_mapping_options.duration_null = value->j;
@@ -817,7 +796,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::DURATION>( const std::str
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::INTERVAL_MONTHS>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::INTERVAL_MONTHS>( const std::string& key, K value )
 {
   if( -KI == value->t ){
     null_mapping_options.month_interval_null = value->i;
@@ -829,7 +808,7 @@ inline void KdbOptions::NullMappingOption<arrow::Type::INTERVAL_MONTHS>( const s
 }
 
 template<>
-inline void KdbOptions::NullMappingOption<arrow::Type::INTERVAL_DAY_TIME>( const std::string& key, K value )
+inline void KdbOptions::HandleNullMapping<arrow::Type::INTERVAL_DAY_TIME>( const std::string& key, K value )
 {
   if( -KJ == value->t ){
     null_mapping_options.day_time_interval_null = value->j;
@@ -841,38 +820,38 @@ inline void KdbOptions::NullMappingOption<arrow::Type::INTERVAL_DAY_TIME>( const
 }
 
 template<arrow::Type::type TypeId>
-auto make_null_mapping()
+auto make_handler()
 {
-  return std::make_pair( TypeId, &KdbOptions::NullMappingOption<TypeId> );
+  return std::make_pair( TypeId, &KdbOptions::HandleNullMapping<TypeId> );
 }
 
 inline const KdbOptions::NullMappingHandlers KdbOptions::null_mapping_handlers = {
-      make_null_mapping<arrow::Type::BOOL>()
-    , make_null_mapping<arrow::Type::UINT8>()
-    , make_null_mapping<arrow::Type::INT8>()
-    , make_null_mapping<arrow::Type::UINT16>()
-    , make_null_mapping<arrow::Type::INT16>()
-    , make_null_mapping<arrow::Type::UINT32>()
-    , make_null_mapping<arrow::Type::INT32>()
-    , make_null_mapping<arrow::Type::UINT64>()
-    , make_null_mapping<arrow::Type::INT64>()
-    , make_null_mapping<arrow::Type::HALF_FLOAT>()
-    , make_null_mapping<arrow::Type::FLOAT>()
-    , make_null_mapping<arrow::Type::DOUBLE>()
-    , make_null_mapping<arrow::Type::STRING>()
-    , make_null_mapping<arrow::Type::LARGE_STRING>()
-    , make_null_mapping<arrow::Type::BINARY>()
-    , make_null_mapping<arrow::Type::LARGE_BINARY>()
-    , make_null_mapping<arrow::Type::FIXED_SIZE_BINARY>()
-    , make_null_mapping<arrow::Type::DATE32>()
-    , make_null_mapping<arrow::Type::DATE64>()
-    , make_null_mapping<arrow::Type::TIMESTAMP>()
-    , make_null_mapping<arrow::Type::TIME32>()
-    , make_null_mapping<arrow::Type::TIME64>()
-    , make_null_mapping<arrow::Type::DECIMAL>()
-    , make_null_mapping<arrow::Type::DURATION>()
-    , make_null_mapping<arrow::Type::INTERVAL_MONTHS>()
-    , make_null_mapping<arrow::Type::INTERVAL_DAY_TIME>()
+      make_handler<arrow::Type::BOOL>()
+    , make_handler<arrow::Type::UINT8>()
+    , make_handler<arrow::Type::INT8>()
+    , make_handler<arrow::Type::UINT16>()
+    , make_handler<arrow::Type::INT16>()
+    , make_handler<arrow::Type::UINT32>()
+    , make_handler<arrow::Type::INT32>()
+    , make_handler<arrow::Type::UINT64>()
+    , make_handler<arrow::Type::INT64>()
+    , make_handler<arrow::Type::HALF_FLOAT>()
+    , make_handler<arrow::Type::FLOAT>()
+    , make_handler<arrow::Type::DOUBLE>()
+    , make_handler<arrow::Type::STRING>()
+    , make_handler<arrow::Type::LARGE_STRING>()
+    , make_handler<arrow::Type::BINARY>()
+    , make_handler<arrow::Type::LARGE_BINARY>()
+    , make_handler<arrow::Type::FIXED_SIZE_BINARY>()
+    , make_handler<arrow::Type::DATE32>()
+    , make_handler<arrow::Type::DATE64>()
+    , make_handler<arrow::Type::TIMESTAMP>()
+    , make_handler<arrow::Type::TIME32>()
+    , make_handler<arrow::Type::TIME64>()
+    , make_handler<arrow::Type::DECIMAL>()
+    , make_handler<arrow::Type::DURATION>()
+    , make_handler<arrow::Type::INTERVAL_MONTHS>()
+    , make_handler<arrow::Type::INTERVAL_DAY_TIME>()
 };
 
 } // namespace arrowkdb

--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -330,7 +330,11 @@ private:
         throw InvalidOption(("Unsupported NULL_MAPPING option '" + key + "'").c_str());
       }
       K value = kK( values )[i];
-      if( ETraits<NM>::name( NM::BOOL ) == key && -KG == value->t ){
+      if( ETraits<NM>::name( NM::BOOL ) == key && -KB == value->t ){
+        null_mapping_options.boolean_null = value->g;
+        null_mapping_options.have_boolean = true;
+      }
+      else if( ETraits<NM>::name( NM::BOOL ) == key && -KG == value->t ){
         null_mapping_options.boolean_null = value->g;
         null_mapping_options.have_boolean = true;
       }

--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -74,8 +74,14 @@ namespace Options
   const std::string NM_LARGE_STRING = "large_string";
   const std::string NM_BINARY = "binary";
   const std::string NM_LARGE_BINARY = "large_binary";
+  const std::string NM_FIXED_BINARY = "fixed_binary";
   const std::string NM_DATE_32 = "date32";
   const std::string NM_DATE_64 = "date64";
+  const std::string NM_TIMESTAMP = "timestamp";
+  const std::string NM_TIME_32 = "time32";
+  const std::string NM_TIME_64 = "time64";
+  const std::string NM_DECIMAL = "decimal";
+  const std::string NM_DURATION = "duration";
   const std::string NM_MONTH_INTERVAL = "month_interval";
   const std::string NM_DAY_TIME_INTERVAL = "day_time_interval";
 
@@ -109,8 +115,14 @@ namespace Options
     , NM_LARGE_STRING
     , NM_BINARY
     , NM_LARGE_BINARY
+    , NM_FIXED_BINARY
     , NM_DATE_32
     , NM_DATE_64
+    , NM_TIMESTAMP
+    , NM_TIME_32
+    , NM_TIME_64
+    , NM_DECIMAL
+    , NM_DURATION
     , NM_MONTH_INTERVAL
     , NM_DAY_TIME_INTERVAL
   };
@@ -134,8 +146,14 @@ namespace Options
       bool have_large_string;
       bool have_binary;
       bool have_large_binary;
+      bool have_fixed_binary;
       bool have_date32;
       bool have_date64;
+      bool have_timestamp;
+      bool have_time32;
+      bool have_time64;
+      bool have_decimal;
+      bool have_duration;
       bool have_month_interval;
       bool have_day_time_interval;
 
@@ -164,9 +182,15 @@ namespace Options
       std::string large_string_null;
       Binary binary_null;
       Binary large_binary_null;
+      Binary fixed_binary_null;
 
       int32_t date32_null;
       int64_t date64_null;
+      int64_t timestamp_null;
+      int32_t time32_null;
+      int64_t time64_null;
+      double decimal_null;
+      int64_t duration_null;
       int32_t month_interval_null;
       int64_t day_time_interval_null;
 
@@ -190,11 +214,17 @@ namespace Options
   template<> inline auto NullMapping::GetOption<arrow::Type::LARGE_STRING>() const{ return std::make_pair( have_large_string, large_string_null ); }
   template<> inline auto NullMapping::GetOption<arrow::Type::BINARY>() const{ return std::make_pair( have_binary, binary_null ); }
   template<> inline auto NullMapping::GetOption<arrow::Type::LARGE_BINARY>() const{ return std::make_pair( have_large_binary, large_binary_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::FIXED_SIZE_BINARY>() const{ return std::make_pair( have_fixed_binary, fixed_binary_null ); }
   template<> inline auto NullMapping::GetOption<arrow::Type::DATE32>() const{ return std::make_pair( have_date32, date32_null ); }
   template<> inline auto NullMapping::GetOption<arrow::Type::DATE64>() const{ return std::make_pair( have_date64, date64_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::TIMESTAMP>() const{ return std::make_pair( have_timestamp, timestamp_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::TIME32>() const{ return std::make_pair( have_time32, time32_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::TIME64>() const{ return std::make_pair( have_time64, time64_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::DECIMAL>() const{ return std::make_pair( have_decimal, decimal_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::DURATION>() const{ return std::make_pair( have_duration, duration_null ); }
   template<> inline auto NullMapping::GetOption<arrow::Type::INTERVAL_MONTHS>() const{ return std::make_pair( have_month_interval, month_interval_null ); }
   template<> inline auto NullMapping::GetOption<arrow::Type::INTERVAL_DAY_TIME>() const{ return std::make_pair( have_day_time_interval, day_time_interval_null ); }
-}
+} // namespace Options
 
 template<>
 inline const ETraits<arrow::Type::type>::Names ETraits<arrow::Type::type>::names{
@@ -215,8 +245,14 @@ inline const ETraits<arrow::Type::type>::Names ETraits<arrow::Type::type>::names
   , { arrow::Type::LARGE_STRING, Options::NM_LARGE_STRING }
   , { arrow::Type::BINARY, Options::NM_BINARY }
   , { arrow::Type::LARGE_BINARY, Options::NM_LARGE_BINARY }
+  , { arrow::Type::FIXED_SIZE_BINARY, Options::NM_FIXED_BINARY }
   , { arrow::Type::DATE32, Options::NM_DATE_32 }
   , { arrow::Type::DATE64, Options::NM_DATE_64 }
+  , { arrow::Type::TIMESTAMP, Options::NM_TIMESTAMP }
+  , { arrow::Type::DATE32, Options::NM_DATE_32 }
+  , { arrow::Type::DATE64, Options::NM_DATE_64 }
+  , { arrow::Type::DECIMAL, Options::NM_DECIMAL }
+  , { arrow::Type::DURATION, Options::NM_DURATION }
   , { arrow::Type::INTERVAL_MONTHS, Options::NM_MONTH_INTERVAL }
   , { arrow::Type::INTERVAL_DAY_TIME, Options::NM_DAY_TIME_INTERVAL }
 };
@@ -358,6 +394,10 @@ private:
         null_mapping_options.large_binary_null.assign( kC( value ), value->n );
         null_mapping_options.have_large_binary = true;
       }
+      else if( ETraits<NM>::name( NM::FIXED_SIZE_BINARY ) == key && KC == value->t ){
+        null_mapping_options.fixed_binary_null.assign( kC( value ), value->n );
+        null_mapping_options.have_fixed_binary = true;
+      }
       else if( ETraits<NM>::name( NM::DATE32 ) == key && -KI == value->t ){
         null_mapping_options.date32_null = value->i;
         null_mapping_options.have_date32 = true;
@@ -365,6 +405,26 @@ private:
       else if( ETraits<NM>::name( NM::DATE64 ) == key && -KJ == value->t ){
         null_mapping_options.date64_null = value->j;
         null_mapping_options.have_date64 = true;
+      }
+      else if( ETraits<NM>::name( NM::TIMESTAMP ) == key && -KJ == value->t ){
+        null_mapping_options.timestamp_null = value->j;
+        null_mapping_options.have_timestamp = true;
+      }
+      else if( ETraits<NM>::name( NM::TIME32 ) == key && -KI == value->t ){
+        null_mapping_options.time32_null = value->i;
+        null_mapping_options.have_time32 = true;
+      }
+      else if( ETraits<NM>::name( NM::TIME64 ) == key && -KJ == value->t ){
+        null_mapping_options.time64_null = value->j;
+        null_mapping_options.have_time64 = true;
+      }
+      else if( ETraits<NM>::name( NM::DECIMAL ) == key && -KF == value->t ){
+        null_mapping_options.decimal_null = value->f;
+        null_mapping_options.have_decimal = true;
+      }
+      else if( ETraits<NM>::name( NM::DURATION ) == key && -KJ == value->t ){
+        null_mapping_options.duration_null = value->j;
+        null_mapping_options.have_duration = true;
       }
       else if( ETraits<NM>::name( NM::INTERVAL_MONTHS ) == key && -KI == value->t ){
         null_mapping_options.month_interval_null = value->i;

--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -9,7 +9,7 @@
 #include <algorithm>
 
 #include "k.h"
-
+#include <arrow/type_fwd.h>
 
 namespace kx {
 namespace arrowkdb {
@@ -117,30 +117,6 @@ namespace Options
 
   struct NullMapping
   {
-      enum class Type: int{
-            NA
-          , BOOLEAN
-          , UINT_8
-          , INT_8
-          , UINT_16
-          , INT_16
-          , UINT_32
-          , INT_32
-          , UINT_64
-          , INT_64
-          , FLOAT_16
-          , FLOAT_32
-          , FLOAT_64
-          , STRING
-          , LARGE_STRING
-          , BINARY
-          , LARGE_BINARY
-          , DATE_32
-          , DATE_64
-          , MONTH_INTERVAL
-          , DAY_TIME_INTERVAL
-      };
-
       bool have_na;
       bool have_boolean;
       bool have_uint8;
@@ -193,32 +169,56 @@ namespace Options
       int64_t date64_null;
       int32_t month_interval_null;
       int64_t day_time_interval_null;
+
+      template<arrow::Type::type TypeId = arrow::Type::NA>
+      auto GetOption() const { return std::make_pair( true, na_null );}
   };
+
+  template<> inline auto NullMapping::GetOption<arrow::Type::BOOL>() const{ return std::make_pair( have_boolean, boolean_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::UINT8>() const{ return std::make_pair( have_uint8, uint8_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::INT8>() const{ return std::make_pair( have_int8, int8_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::UINT16>() const{ return std::make_pair( have_uint16, uint16_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::INT16>() const{ return std::make_pair( have_int16, int16_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::UINT32>() const{ return std::make_pair( have_uint32, uint32_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::INT32>() const{ return std::make_pair( have_int32, int32_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::UINT64>() const{ return std::make_pair( have_uint64, uint64_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::INT64>() const{ return std::make_pair( have_int64, int64_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::HALF_FLOAT>() const{ return std::make_pair( have_float16, float16_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::FLOAT>() const{ return std::make_pair( have_float32, float32_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::DOUBLE>() const{ return std::make_pair( have_float64, float64_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::STRING>() const{ return std::make_pair( have_string, string_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::LARGE_STRING>() const{ return std::make_pair( have_large_string, large_string_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::BINARY>() const{ return std::make_pair( have_binary, binary_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::LARGE_BINARY>() const{ return std::make_pair( have_large_binary, large_binary_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::DATE32>() const{ return std::make_pair( have_date32, date32_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::DATE64>() const{ return std::make_pair( have_date64, date64_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::INTERVAL_MONTHS>() const{ return std::make_pair( have_month_interval, month_interval_null ); }
+  template<> inline auto NullMapping::GetOption<arrow::Type::INTERVAL_DAY_TIME>() const{ return std::make_pair( have_day_time_interval, day_time_interval_null ); }
 }
 
 template<>
-inline const ETraits< Options::NullMapping::Type >::Names ETraits< Options::NullMapping::Type >::names {
-    { Options::NullMapping::Type::NA, Options::NM_NA }
-  , { Options::NullMapping::Type::BOOLEAN, Options::NM_BOOLEAN }
-  , { Options::NullMapping::Type::UINT_8, Options::NM_UINT_8 }
-  , { Options::NullMapping::Type::INT_8, Options::NM_INT_8 }
-  , { Options::NullMapping::Type::UINT_16, Options::NM_UINT_16 }
-  , { Options::NullMapping::Type::INT_16, Options::NM_INT_16 }
-  , { Options::NullMapping::Type::UINT_32, Options::NM_UINT_32 }
-  , { Options::NullMapping::Type::INT_32, Options::NM_INT_32 }
-  , { Options::NullMapping::Type::UINT_64, Options::NM_UINT_64 }
-  , { Options::NullMapping::Type::INT_64, Options::NM_INT_64 }
-  , { Options::NullMapping::Type::FLOAT_16, Options::NM_FLOAT_16 }
-  , { Options::NullMapping::Type::FLOAT_32, Options::NM_FLOAT_32 }
-  , { Options::NullMapping::Type::FLOAT_64, Options::NM_FLOAT_64 }
-  , { Options::NullMapping::Type::STRING, Options::NM_STRING }
-  , { Options::NullMapping::Type::LARGE_STRING, Options::NM_LARGE_STRING }
-  , { Options::NullMapping::Type::BINARY, Options::NM_BINARY }
-  , { Options::NullMapping::Type::LARGE_BINARY, Options::NM_LARGE_BINARY }
-  , { Options::NullMapping::Type::DATE_32, Options::NM_DATE_32 }
-  , { Options::NullMapping::Type::DATE_64, Options::NM_DATE_64 }
-  , { Options::NullMapping::Type::MONTH_INTERVAL, Options::NM_MONTH_INTERVAL }
-  , { Options::NullMapping::Type::DAY_TIME_INTERVAL, Options::NM_DAY_TIME_INTERVAL }
+inline const ETraits<arrow::Type::type>::Names ETraits<arrow::Type::type>::names{
+    { arrow::Type::NA, Options::NM_NA }
+  , { arrow::Type::BOOL, Options::NM_BOOLEAN }
+  , { arrow::Type::UINT8, Options::NM_UINT_8 }
+  , { arrow::Type::INT8, Options::NM_INT_8 }
+  , { arrow::Type::UINT16, Options::NM_UINT_16 }
+  , { arrow::Type::INT16, Options::NM_INT_16 }
+  , { arrow::Type::UINT32, Options::NM_UINT_32 }
+  , { arrow::Type::INT32, Options::NM_INT_32 }
+  , { arrow::Type::UINT64, Options::NM_UINT_64 }
+  , { arrow::Type::INT64, Options::NM_INT_64 }
+  , { arrow::Type::HALF_FLOAT, Options::NM_FLOAT_16 }
+  , { arrow::Type::FLOAT, Options::NM_FLOAT_32 }
+  , { arrow::Type::DOUBLE, Options::NM_FLOAT_64 }
+  , { arrow::Type::STRING, Options::NM_STRING }
+  , { arrow::Type::LARGE_STRING, Options::NM_LARGE_STRING }
+  , { arrow::Type::BINARY, Options::NM_BINARY }
+  , { arrow::Type::LARGE_BINARY, Options::NM_LARGE_BINARY }
+  , { arrow::Type::DATE32, Options::NM_DATE_32 }
+  , { arrow::Type::DATE64, Options::NM_DATE_64 }
+  , { arrow::Type::INTERVAL_MONTHS, Options::NM_MONTH_INTERVAL }
+  , { arrow::Type::INTERVAL_DAY_TIME, Options::NM_DAY_TIME_INTERVAL }
 };
 
 // Helper class for reading dictionary of options
@@ -278,7 +278,7 @@ private:
 
   void PopulateNullMappingOptions( long long index, K dict )
   {
-    using NM = Options::NullMapping::Type;
+    using NM = arrow::Type::type;
 
     K keys = kK( kK( dict )[index] )[0];
     K values = kK( kK( dict )[index] )[1];
@@ -294,51 +294,51 @@ private:
         throw InvalidOption(("Unsupported NULL_MAPPING option '" + key + "'").c_str());
       }
       K value = kK( values )[i];
-      if( ETraits<NM>::name( NM::BOOLEAN ) == key && -KG == value->t ){
+      if( ETraits<NM>::name( NM::BOOL ) == key && -KG == value->t ){
         null_mapping_options.boolean_null = value->g;
         null_mapping_options.have_boolean = true;
       }
-      else if( ETraits<NM>::name( NM::UINT_8 ) == key && -KG == value->t ){
+      else if( ETraits<NM>::name( NM::UINT8 ) == key && -KG == value->t ){
         null_mapping_options.uint8_null = value->g;
         null_mapping_options.have_uint8 = true;
       }
-      else if( ETraits<NM>::name( NM::INT_8 ) == key && -KG == value->t ){
+      else if( ETraits<NM>::name( NM::INT8 ) == key && -KG == value->t ){
         null_mapping_options.int8_null = value->g;
         null_mapping_options.have_int8 = true;
       }
-      else if( ETraits<NM>::name( NM::UINT_16 ) == key && -KH == value->t ){
+      else if( ETraits<NM>::name( NM::UINT16 ) == key && -KH == value->t ){
         null_mapping_options.uint16_null = value->h;
         null_mapping_options.have_uint16 = true;
       }
-      else if( ETraits<NM>::name( NM::INT_16 ) == key && -KH == value->t ){
+      else if( ETraits<NM>::name( NM::INT16 ) == key && -KH == value->t ){
         null_mapping_options.int16_null = value->h;
         null_mapping_options.have_int16 = true;
       }
-      else if( ETraits<NM>::name( NM::UINT_32 ) == key && -KI == value->t ){
+      else if( ETraits<NM>::name( NM::UINT32 ) == key && -KI == value->t ){
         null_mapping_options.uint32_null = value->i;
         null_mapping_options.have_uint32 = true;
       }
-      else if( ETraits<NM>::name( NM::INT_32 ) == key && -KI == value->t ){
+      else if( ETraits<NM>::name( NM::INT32 ) == key && -KI == value->t ){
         null_mapping_options.int32_null = value->i;
         null_mapping_options.have_int32 = true;
       }
-      else if( ETraits<NM>::name( NM::UINT_64 ) == key && -KJ == value->t ){
+      else if( ETraits<NM>::name( NM::UINT64 ) == key && -KJ == value->t ){
         null_mapping_options.uint64_null = value->j;
         null_mapping_options.have_uint64 = true;
       }
-      else if( ETraits<NM>::name( NM::INT_64 ) == key && -KJ == value->t ){
+      else if( ETraits<NM>::name( NM::INT64 ) == key && -KJ == value->t ){
         null_mapping_options.int64_null = value->j;
         null_mapping_options.have_int64 = true;
       }
-      else if( ETraits<NM>::name( NM::FLOAT_16 ) == key && -KH == value->t ){
+      else if( ETraits<NM>::name( NM::HALF_FLOAT ) == key && -KH == value->t ){
         null_mapping_options.float16_null = value->h;
         null_mapping_options.have_float16 = true;
       }
-      else if( ETraits<NM>::name( NM::FLOAT_32 ) == key && -KE == value->t ){
+      else if( ETraits<NM>::name( NM::FLOAT ) == key && -KE == value->t ){
         null_mapping_options.float32_null = value->e;
         null_mapping_options.have_float32 = true;
       }
-      else if( ETraits<NM>::name( NM::FLOAT_64 ) == key && -KF == value->t ){
+      else if( ETraits<NM>::name( NM::DOUBLE ) == key && -KF == value->t ){
         null_mapping_options.float64_null = value->f;
         null_mapping_options.have_float64 = true;
       }
@@ -358,19 +358,19 @@ private:
         null_mapping_options.large_binary_null.assign( kC( value ), value->n );
         null_mapping_options.have_large_binary = true;
       }
-      else if( ETraits<NM>::name( NM::DATE_32 ) == key && -KI == value->t ){
+      else if( ETraits<NM>::name( NM::DATE32 ) == key && -KI == value->t ){
         null_mapping_options.date32_null = value->i;
         null_mapping_options.have_date32 = true;
       }
-      else if( ETraits<NM>::name( NM::DATE_64 ) == key && -KJ == value->t ){
+      else if( ETraits<NM>::name( NM::DATE64 ) == key && -KJ == value->t ){
         null_mapping_options.date64_null = value->j;
         null_mapping_options.have_date64 = true;
       }
-      else if( ETraits<NM>::name( NM::MONTH_INTERVAL ) == key && -KI == value->t ){
+      else if( ETraits<NM>::name( NM::INTERVAL_MONTHS ) == key && -KI == value->t ){
         null_mapping_options.month_interval_null = value->i;
         null_mapping_options.have_month_interval = true;
       }
-      else if( ETraits<NM>::name( NM::DAY_TIME_INTERVAL ) == key && -KJ == value->t ){
+      else if( ETraits<NM>::name( NM::INTERVAL_DAY_TIME ) == key && -KJ == value->t ){
         null_mapping_options.day_time_interval_null = value->j;
         null_mapping_options.have_day_time_interval = true;
       }
@@ -486,12 +486,8 @@ public:
     }
   }
 
-  template<Options::NullMapping::Type TypeId = Options::NullMapping::Type::NA>
-  auto GetNullMappingOption( bool& result ) {
-      result = true;
-
-      return null_mapping_options.na_null;
-  }
+  template<arrow::Type::type TypeId = arrow::Type::NA>
+  auto GetNullMappingOption() const { return null_mapping_options.GetOption<TypeId>(); }
 
   void GetNullMappingOptions( Options::NullMapping& null_mapping ) const
   {
@@ -520,127 +516,6 @@ public:
     }
   }
 };
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::BOOLEAN>( bool& result ){
-    result = null_mapping_options.have_boolean;
-    return null_mapping_options.boolean_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::UINT_8>( bool& result ){
-    result = null_mapping_options.have_uint8;
-    return null_mapping_options.uint8_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_8>( bool& result ){
-    result = null_mapping_options.have_int8;
-    return null_mapping_options.int8_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::UINT_16>( bool& result ){
-    result = null_mapping_options.have_uint16;
-    return null_mapping_options.uint16_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_16>( bool& result ){
-    result = null_mapping_options.have_int16;
-    return null_mapping_options.int16_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::UINT_32>( bool& result ){
-    result = null_mapping_options.have_uint32;
-    return null_mapping_options.uint32_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_32>( bool& result ){
-    result = null_mapping_options.have_int32;
-    return null_mapping_options.int32_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::UINT_64>( bool& result ){
-    result = null_mapping_options.have_uint64;
-    return null_mapping_options.uint64_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::INT_64>( bool& result ){
-    result = null_mapping_options.have_int64;
-    return null_mapping_options.int64_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::FLOAT_16>( bool& result ){
-    result = null_mapping_options.have_float16;
-    return null_mapping_options.float16_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::FLOAT_32>( bool& result ){
-    result = null_mapping_options.have_float32;
-    return null_mapping_options.float32_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::FLOAT_64>( bool& result ){
-    result = null_mapping_options.have_float64;
-    return null_mapping_options.float64_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::STRING>( bool& result ){
-    result = null_mapping_options.have_string;
-    return null_mapping_options.string_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::LARGE_STRING>( bool& result ){
-    result = null_mapping_options.have_large_string;
-    return null_mapping_options.large_string_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::BINARY>( bool& result ){
-    result = null_mapping_options.have_binary;
-    return null_mapping_options.binary_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::LARGE_BINARY>( bool& result ){
-    result = null_mapping_options.have_large_binary;
-    return null_mapping_options.large_binary_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::DATE_32>( bool& result ){
-    result = null_mapping_options.have_date32;
-    return null_mapping_options.date32_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::DATE_64>( bool& result ){
-    result = null_mapping_options.have_date64;
-    return null_mapping_options.date64_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::MONTH_INTERVAL>( bool& result ){
-    result = null_mapping_options.have_month_interval;
-    return null_mapping_options.month_interval_null;
-}
-
-template<>
-inline auto KdbOptions::GetNullMappingOption<Options::NullMapping::Type::DAY_TIME_INTERVAL>( bool& result ){
-    result = null_mapping_options.have_day_time_interval;
-    return null_mapping_options.day_time_interval_null;
-}
-
 
 } // namespace arrowkdb
 } // namespace kx

--- a/src/SchemaStore.cpp
+++ b/src/SchemaStore.cpp
@@ -143,7 +143,7 @@ K inferSchema(K table)
 
   // Determine the arrow datatype for each data set
   K k_array_data = kK(dict)[1];
-  assert(k_array_data->n == field_names.size());
+  assert(static_cast<std::size_t>( k_array_data->n ) == field_names.size());
   arrow::FieldVector fields;
   for (auto i = 0ul; i < field_names.size(); ++i) {
     auto datatype = kx::arrowkdb::GetArrowType(kK(k_array_data)[i]);


### PR DESCRIPTION
Supporting null mapping of arrow types according to mockup test in q

https://kxl.atlassian.net/browse/KXI-21090