### PR TITLE
Allow for Arrow to compress Parquet tables upon write

### DIFF
--- a/src/KdbOptions.h
+++ b/src/KdbOptions.h
@@ -29,6 +29,7 @@ namespace Options
 
   // String options
   const std::string PARQUET_VERSION = "PARQUET_VERSION";
+  const std::string COMPRESSION = "COMPRESSION";
 
   // Dict options
   const std::string NULL_MAPPING = "NULL_MAPPING";
@@ -72,6 +73,7 @@ namespace Options
   };
   const static std::set<std::string> string_options = {
     PARQUET_VERSION,
+    COMPRESSION,
   };
   const static std::set<std::string> dict_options = {
     NULL_MAPPING,

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -151,6 +151,29 @@ K writeReadTable(K schema_id, K array_data, K options)
   KDB_EXCEPTION_CATCH;
 }
 
+arrow::Compression::type getCompressionType(std::string compression) {
+  if (compression == "SNAPPY") {
+    return arrow::Compression::SNAPPY;
+  } else if (compression ==  "GZIP") {
+    return arrow::Compression::GZIP;
+  } else if (compression == "BROTLI") {
+    return arrow::Compression::BROTLI;
+  } else if (compression == "ZSTD") {
+    return arrow::Compression::ZSTD;
+  } else if (compression == "LZ4") {
+    return arrow::Compression::LZ4;
+  } else if (compression == "LZ4_FRAME") {
+    return arrow::Compression::LZ4_FRAME;
+  } else if (compression == "LZO") {
+    return arrow::Compression::LZO;
+  } else if (compression == "BZ2") {
+    return arrow::Compression::BZ2;
+  } else if (compression == "LZ4_HADOOP") {
+    return arrow::Compression::LZ4_HADOOP;
+  }
+  return arrow::Compression::UNCOMPRESSED;
+}
+
 K writeParquet(K parquet_file, K schema_id, K array_data, K options)
 {
   KDB_EXCEPTION_TRY;
@@ -201,10 +224,15 @@ K writeParquet(K parquet_file, K schema_id, K array_data, K options)
     arrow_props_builder.allow_truncated_timestamps();
   }
 
+  // Compression
+  std::string compression;
+  write_options.GetStringOption(kx::arrowkdb::Options::COMPRESSION, compression);
+  arrow::Compression::type compression_type = getCompressionType(compression);
+
   // Type mapping overrides
   kx::arrowkdb::TypeMappingOverride type_overrides{ write_options };
 
-  auto parquet_props = parquet_props_builder.build();
+  auto parquet_props = parquet_props_builder.compression(compression_type)->build();
   auto arrow_props = arrow_props_builder.build();
 
   // Create the arrow table

--- a/src/TableData.h
+++ b/src/TableData.h
@@ -92,6 +92,11 @@ extern "C"
    * featured but may be incompatible with older Parquet implementations.
    * Default `V1.0`
    *
+   * COMPRESSION (string) - Selects the compression type for Arrow to use
+   * when writing Parquet files. Relevant libraries must be present in path.
+   * Values supported: `UNCOMPRESSED` (default), `SNAPPY`, `GZIP`, `BROTLI`,
+   * `ZSTD`, `LZ4`, `LZ4_FRAME`, `LZO`, `BZ2`, `LZ4_HADOOP`.
+   *
    * DECIMAL128_AS_DOUBLE (long) - Flag indicating whether to override the
    * default type mapping for the arrow decimal128 datatype and instead
    * represent it as a double (9h).  Default 0.

--- a/tests/basic.t
+++ b/tests/basic.t
@@ -424,6 +424,38 @@ ipc.parseArrowData[serialized;::]~array_data
 sc.removeSchema[schema]
 
 
+-1 "\n+----------|| Test compression in Parquet ||----------+\n";
+
+fields:(uint8_fd,int8_fd,uint16_fd,int16_fd,uint32_fd,int32_fd,uint64_fd,int64_fd)
+schema:sc.schema[fields]
+sc.schemaFields[schema]~fields
+array_data:(uint8_data;int8_data;uint16_data;int16_data;uint32_data;int32_data;uint64_data;int64_data)
+
+-1 "<--- Read/write GZIP parquet --->";
+
+// Use Parquet v2.0 & GZIP compression
+parquet_write_options:(`PARQUET_VERSION`COMPRESSION)!(`V2.0`GZIP)
+
+filename:"gzip.parquet"
+pq.writeParquet[filename;schema;array_data;parquet_write_options]
+pq.readParquetSchema[filename]~schema
+pq.readParquetData[filename;::]~array_data
+rm filename;
+
+-1 "<--- Read/write SNAPPY parquet --->";
+
+// Use Parquet v2.0 & SNAPPY compression
+parquet_write_options:(`PARQUET_VERSION`COMPRESSION)!(`V2.0`SNAPPY)
+
+filename:"snappy.parquet"
+pq.writeParquet[filename;schema;array_data;parquet_write_options]
+pq.readParquetSchema[filename]~schema
+pq.readParquetData[filename;::]~array_data
+rm filename;
+
+sc.removeSchema[schema]
+
+
 -1 "\n+----------|| Clean up the constructed fields and datatypes ||----------+\n";
 
 sc.listSchemas[]~`int$()


### PR DESCRIPTION
Compression is handled within Arrow already, provided that the requested libraries are available for Arrow to reference (e.g. via LD_LIBRARY_PATH on Linux). Most builds of arrow should natively support at least GZIP and SNAPPY, in addition to UNCOMPRESSED (the default). Attempting to use a compression codec that isn't available at runtime will result in a q crash.